### PR TITLE
module_variable_optional_attrs is not experimental

### DIFF
--- a/_main.tf
+++ b/_main.tf
@@ -2,10 +2,7 @@
 
 # region Module Requirements ###################################################
 terraform {
-	required_version = ">= 0.12"
-	experiments = [
-		module_variable_optional_attrs,
-	]
+	required_version = ">= 1.3"
 	required_providers {
 		aws = {
 			source = "hashicorp/aws"


### PR DESCRIPTION
From terraform 1.3, module_variable_optional_attrs is not an experiment anymore.

I had to make this change to be able to use the module with terraform > 1.3